### PR TITLE
fix: fix rare macro bug with fix from FamiStudio dev.

### DIFF
--- a/asm6.c
+++ b/asm6.c
@@ -1637,6 +1637,8 @@ void equ(label *id, char **next) {
             }
         } else if((*labelhere).type!=EQUATE) {
             errmsg=LabelDefined;
+        } else {
+            (*labelhere).line = my_strdup(s);
         }
         *s=0;//end line
     }


### PR DESCRIPTION
Applies the fix to asm6 used by famistudio and described here:

https://famistudio.org/doc/soundengine/#issues-with-asm6

I know this project hasn't been updated in a while, but it seemed like it'd be good if the fix was upstreamed.